### PR TITLE
Hotfix for ignore attributes and test clarification

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,6 +7,8 @@
 ExampleDataSetAndProject
 CodeParkingLot
 distance_old
+TestingFolder
+Testing
 .tar.gz$
 .zip$
 ^data-raw$

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ Icon
 CodeParkingLot
 ExampleDataSetAndProject
 distance_old
+TestingFolder
+Testing
 Rdistance*.zip
 Rdistance*.tar.gz
 Rdistance*.piz

--- a/tests/testthat/test_lines_covars.R
+++ b/tests/testthat/test_lines_covars.R
@@ -68,6 +68,9 @@ require(Rdistance)
 
 # The first required dataset is a detection data.frame
 # Each row is a detection, and the siteID, groupsize, and dist columns are required (as named)
+context("Test the linesCovars() function")
+
+test_that("linesCovars() works well", {
 data(sparrowDetectionData)
 head(sparrowDetectionData)
 
@@ -329,5 +332,6 @@ ds.fit$dht$individuals$N  # 0.8753126 (0.6918557 - 1.107416)
 coef(fit)  # (Intercept)=3.880301; zBare=0.109066 
      
 ds.fit$ddf$ds$aux$ddfobj$scale$parameters  # Intercept =  3.8802998 , zBare = 0.1090674
+})
 
 

--- a/tests/testthat/test_lines_covars.R
+++ b/tests/testthat/test_lines_covars.R
@@ -68,9 +68,9 @@ require(Rdistance)
 
 # The first required dataset is a detection data.frame
 # Each row is a detection, and the siteID, groupsize, and dist columns are required (as named)
-context("Test the linesCovars() function")
+context("Test the lines_Covars() function")
 
-test_that("linesCovars() works well", {
+test_that("lines_Covars() operates as it should", {
 data(sparrowDetectionData)
 head(sparrowDetectionData)
 

--- a/tests/testthat/test_lines_noCovars.R
+++ b/tests/testthat/test_lines_noCovars.R
@@ -68,6 +68,9 @@ require(Rdistance)
 
 # The first required dataset is a detection data.frame
 # Each row is a detection, and the siteID, groupsize, and dist columns are required (as named)
+context("Test the lines_noCovars() function")
+
+test_that("lines_noCovars Covars() operates as it should", {
 data(sparrowDetectionData)
 head(sparrowDetectionData)
 
@@ -273,3 +276,4 @@ ds.fit$dht$individuals$N  # 0.8634164 (0.6943432 - 1.073659)
 # Sigma
 coef(fit)  # 46.35884
 exp(ds.fit$ddf$ds$aux$ddfobj$scale$parameters)  # 46.35865
+})

--- a/tests/testthat/test_points_covars.R
+++ b/tests/testthat/test_points_covars.R
@@ -24,6 +24,9 @@
 
 # The first required dataset is a detection data.frame
 # Each row is a detection, and the siteID, groupsize, and dist columns are required (as named)
+context("Test the lines_points_Covars() function")
+
+test_that("lines_points_Covars() operates as it should", {
 data(thrasherDetectionData)
 head(thrasherDetectionData)
 
@@ -232,5 +235,6 @@ ds.fit$dht$individuals$N  # 0.4910311 (0.3917012 - 0.6155497)
 # Sigma
 coef(fit)  # Intercept = 4.63149158, dummy = -0.09736296
 ds.fit$ddf$ds$aux$ddfobj$scale$parameters  # Intercept = 4.63150603, dummy = -0.09736732
+})
 
 

--- a/tests/testthat/test_points_noCovars.R
+++ b/tests/testthat/test_points_noCovars.R
@@ -24,6 +24,9 @@
 
 # The first required dataset is a detection data.frame
 # Each row is a detection, and the siteID, groupsize, and dist columns are required (as named)
+context("Test the points_noCovars() function")
+
+test_that("points_noCovars() operates as it should", {
 data(thrasherDetectionData)
 head(thrasherDetectionData)
 
@@ -197,4 +200,4 @@ ds.fit$dht$individuals$N  # 0.4686923 (0.3792886 - 0.5791696)
 # Sigma
 coef(fit)  # 73.57595
 exp(ds.fit$ddf$ds$aux$ddfobj$scale$parameters)  # 73.57655
-
+})


### PR DESCRIPTION
A word of caution, because the tests written by Jason do no fit the standard keywords used by the "testthat" library, many of his tests show up as a warning. This is also caused by the fact that he calls many different data-frames in from other files, which is not generally supported by "test_that" functionality. Everything that is being used for testing, must be native to the testing file for a big green check mark to appear, so to speak. It looks like Jason's tests work well, they just aren't clearly recognized by the Travis-CI pipeline. 