### PR TITLE
Issue 77

### DIFF
--- a/R/integration.constant.R
+++ b/R/integration.constant.R
@@ -166,7 +166,8 @@ integration.constant <- function(dist,
     else {
       # User defined likelihood case.  
       for(i in 1:nrow(unique.covars)){
-        temp.covars <- matrix(unique.covars[i,-PkeyCol],nrow=length(seqx),
+        # temp.covars <- matrix(unique.covars[i,-PkeyCol],nrow=length(seqx),
+        temp.covars <- matrix(unlist(unique.covars[i,-PkeyCol]),nrow=length(seqx),
                               ncol=ncol(unique.covars)-1, byrow=TRUE)
         seqy[[i]] <- density(dist = seqx, covars = temp.covars, 
                              scale = FALSE, w.lo = w.lo, w.hi = w.hi, 

--- a/R/integration.constant.R
+++ b/R/integration.constant.R
@@ -166,7 +166,6 @@ integration.constant <- function(dist,
     else {
       # User defined likelihood case.  
       for(i in 1:nrow(unique.covars)){
-        # temp.covars <- matrix(unique.covars[i,-PkeyCol],nrow=length(seqx),
         temp.covars <- matrix(unlist(unique.covars[i,-PkeyCol]),nrow=length(seqx),
                               ncol=ncol(unique.covars)-1, byrow=TRUE)
         seqy[[i]] <- density(dist = seqx, covars = temp.covars, 


### PR DESCRIPTION
This branch modifies integration.constant.R and so fixes issue 77. It unlists a dataframe row that is used to populate a matrix, temp.covars. This makes the matrix of type 'numeric' rather than type 'list' and so downstream matrix multiplication can proceed as intended.
