### PR TITLE
Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,11 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
-  # - Rscript -e 'devtools::install();devtools::test_package()'
+  - Rscript -e 'devtools::install();devtools::test_package()'
 
 #report coverage for release version
 after_success:
   - test $TRAVIS_R_VERSION_STRING = 'release' && Rscript -e 'covr::codecov()'
-  - Rscript -e 'devtools::install();devtools::test_package()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,12 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
+  - Rscript -e 'devtools::install();devtools::test()'
 
 #report coverage for release version
 after_success:
   - test $TRAVIS_R_VERSION_STRING = 'release' && Rscript -e 'covr::codecov()'
-  - Rscript -e 'devtools::install();devtools::test()'
+  # - Rscript -e 'devtools::install();devtools::test()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
-  - Rscript -e 'devtools::install();devtools::test_package()'
+  - Rscript -e 'devtools::install();devtools::test(stop_on_failure = TRUE)'
 
 #report coverage for release version
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
-  - Rscript -e 'devtools::install();devtools::test()'
+  - Rscript -e 'devtools::install();devtools::test_package()'
 
 #report coverage for release version
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
-  - Rscript -e 'devtools::install();devtools::test_package()'
+  # - Rscript -e 'devtools::install();devtools::test_package()'
 
 #report coverage for release version
 after_success:
   - test $TRAVIS_R_VERSION_STRING = 'release' && Rscript -e 'covr::codecov()'
-  # - Rscript -e 'devtools::install();devtools::test()'
+  - Rscript -e 'devtools::install();devtools::test_package()'
 
 notifications:
   email:

--- a/tests/testthat/test_simple.expansion.r
+++ b/tests/testthat/test_simple.expansion.r
@@ -22,8 +22,7 @@ exp_3 <- simple.expansion(x, 3)
 exp_4 <- simple.expansion(x, 4)
 
 test_that("expansion of 1.5 generates expected results", {
-  expect_equal(simple.expansion(x, 2), exp_1.5)
-  # expect_equal(simple.expansion(x, 1.5), exp_1.5)
+  expect_equal(simple.expansion(x, 1.5), exp_1.5)
 })
 
 test_that("expansion of 2 generates expected results", {

--- a/tests/testthat/test_simple.expansion.r
+++ b/tests/testthat/test_simple.expansion.r
@@ -22,7 +22,8 @@ exp_3 <- simple.expansion(x, 3)
 exp_4 <- simple.expansion(x, 4)
 
 test_that("expansion of 1.5 generates expected results", {
-  expect_equal(simple.expansion(x, 1.5), exp_1.5)
+  expect_equal(simple.expansion(x, 2), exp_1.5)
+  # expect_equal(simple.expansion(x, 1.5), exp_1.5)
 })
 
 test_that("expansion of 2 generates expected results", {


### PR DESCRIPTION
this branch adds the argument stop_on_failure = TRUE to devtools::test(), and moves its call from the after_success section to the script section (travis.yml file). This change enables Travis CI to fail builds when tests do not pass (as is the desired behavior of Travis CI).